### PR TITLE
Fix: remove uneeded stty in master process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ $ stack install
 ```bash
 $ rpw bash
 $ sudo echo hello!
-[sudo] password for foobar: (rpw..sudo) <-        # type your password and end with C-j
+[sudo] password for foobar: (rpw..sudo) <-        # type your password and
+                                                  # end with `Enter`, `C-j` or `C-m`
 hello!
 $ sudo -k
 $ sudo echo hello!
@@ -36,6 +37,5 @@ SUDO password: <- (rpw..cached)                   # no need to type here!
 
 ## TODO
 
-- [ ] Find out why we need to `C-j` to enter the password, or why `Enter` does not work. 🤔
 - [ ] Allow resetting the password without exiting the shell.
 - [ ] Emit `SIGWINCH` to the slave terminal when needed.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -114,19 +114,6 @@ main = do
   handle
     ((\_ -> signalProcess softwareTermination pid) :: SomeException -> IO ()) $
     withoutEcho $ do
-      masterPts <- getTerminalName stdInput
-      -- prepare user terminal to control the slave
-      void $
-        getProcessStatus True False =<<
-        forkProcess
-          (executeFile
-             "sh"
-             True
-             [ "-c"
-             , "/bin/stty raw -echo -echoctl -echok -echoke -echoe -iexten -onlcr < " <>
-               masterPts
-             ]
-             (Just env))
       master <- forkIO $ masterLoop masterH "" Nothing regex
       -- forward C-c to slave
       _ <-


### PR DESCRIPTION
Now we can use either `Enter`, `C-j` or `C-m` to enter password!