### PR TITLE
Fix for fzf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: xenial
 language: generic
 
@@ -13,7 +14,7 @@ addons:
     update: true
 
 before_install:
-  - docker pull thalesmg/rpw_test:v2.0
+  - docker pull thalesmg/rpw_test:v2.1
   - mkdir -p ~/.local/bin
   - export PATH=$HOME/.local/bin:$PATH
   - travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
@@ -23,17 +24,17 @@ install:
 
 script:
   - stack --no-terminal install --flag "rpw:rpw_dist" --local-bin-path "$PWD"
-  - docker run --rm -e userid=$UID -v $PWD:/mnt thalesmg/rpw_test:v2.0 /mnt/run_tests
+  - docker run --rm -e userid=$UID -v $PWD:/mnt thalesmg/rpw_test:v2.1 /mnt/run_tests
   - sha256sum rpw > rpw.sha256.txt
 
 deploy:
   provider: releases
-  api_key:
+  token:
     secure: PvuwLzbX0ezJozcBENZ1g4zkxP9RBaRl9Xk0xAEyuL/Md5+OPTMm6h52QoCcmo+0dx4dTPA28F0r5v1XNPI2hlN6oFi7b+RBoesIZ9EYBkmwTlTMFRSkanIw0F6h9MeTodJXc/6qEOzu9vV114j/dpRtGFsXI6pKzkVV5NKTncIUzzaiN2MkQXm9pUm5RvY8vdzfDK1IIeMgCWalOjNOIS+J+QFlvMBVg/1N+y1BuK4vQfvm/++Ay+9+zku37dp4m6EwB+AYA3ZM7rheMfbbPlvPpUmcPa8PMf/blW1zEQm1f4IBcbinhaiHLxtuKBxL0cO9xesybbCfPk2xqqN2YPU2N2beLyt0qyk95+dtgkrdRrSN06PoLmQ/JVH8tpK/C+n7rHwY4Yp+/4X5YAPu4VvHTPgRYUM2Hx/nVlIW/V1xV4W68cDH5ExnYwDI4LsG6/M0d59Kn9+5QbGbIeFr8pxaQaKFEHz/kwmjLVpEbFJiHMj+ehQmrzUDkCb2A8zcYiWCfiRDSeup/KbhGtK7fQCpkWdGrJFLcV8LYvrRbkJU4aezxxZi3hA+HMzbG0MsVvjbLmW851lTnLKBTaIUJJL60QLgFFPRYjOa7Alx5GkvvDUylfl2hNrrXhWAPO2q/VbS+wlNvRQl0OSOh12+lFKFCOkuSJRVlFLH7mv918A=
   file:
     - rpw
     - rpw.sha256.txt
-  skip_cleanup: true
+  cleanup: false
   on:
     repo: thalesmg/rpw
     branch: master

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 UID := $(shell id -u)
-DOCKER_IMAGE := thalesmg/rpw_test:v2.0
+DOCKER_IMAGE := thalesmg/rpw_test:v2.1
 
 build: app/Main.hs
 	docker-compose -f ext/docker/rpw.yml up -d rpw

--- a/ext/bin/in-container
+++ b/ext/bin/in-container
@@ -3,10 +3,11 @@
 set -x
 
 BASEDIR=$(realpath $(dirname $(realpath $0))/../..)
+DOCKER_IMAGE=${DOCKER_IMAGE:-thalesmg/rpw_test:v2.1}
 
 if [[ -n $interactive ]]
 then
   DOCKER_FLAGS="-it"
 fi
 
-docker run --rm $DOCKER_FLAGS -e userid=$UID -v $BASEDIR:/mnt thalesmg/rpw_test:v2.0 "$@"
+docker run --rm $DOCKER_FLAGS -e userid=$UID -v $BASEDIR:/mnt $DOCKER_IMAGE "$@"

--- a/ext/docker/rpw/Dockerfile
+++ b/ext/docker/rpw/Dockerfile
@@ -1,1 +1,1 @@
-FROM thalesmg/rpw_test:v2.0
+FROM thalesmg/rpw_test:v2.1

--- a/ext/docker/rpw/make_image
+++ b/ext/docker/rpw/make_image
@@ -1,7 +1,9 @@
-FROM haskell:8.6.5
+FROM haskell:8.10.2
 
 RUN apt update -q && \
-        apt install -qyy sudo python3 expect zsh bash && \
+        apt install -qyy sudo python3 expect zsh bash fzf && \
         rm -rf /var/lib/apt/lists/*
+
+RUN stack setup --resolver lts-17.0
 
 WORKDIR /mnt

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: lts-14.7
+resolver: lts-17.0
 packages:
   - .
 extra-deps:
-  - posix-pty-0.2.1.1@sha256:f1e54f10c49d9f27dba33539391659d2daa4874badc1554ffc6c25b329ef1db6,2161
+  - posix-pty-0.2.2@sha256:dd777df258b3b95fe01612c1204cde972ad1323c3289591ecc844ecb29e55e2b,1826

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,15 +5,15 @@
 
 packages:
 - completed:
-    hackage: posix-pty-0.2.1.1@sha256:f1e54f10c49d9f27dba33539391659d2daa4874badc1554ffc6c25b329ef1db6,2161
+    hackage: posix-pty-0.2.2@sha256:dd777df258b3b95fe01612c1204cde972ad1323c3289591ecc844ecb29e55e2b,1826
     pantry-tree:
       size: 512
-      sha256: d8901f7c8c42c767092262da42e1ff1911151310f4cd87f1ee278d168121ecee
+      sha256: 1165406e7998cf570fad6274a406c0e8c08357a1e60668f9cc8c0f269f457e30
   original:
-    hackage: posix-pty-0.2.1.1@sha256:f1e54f10c49d9f27dba33539391659d2daa4874badc1554ffc6c25b329ef1db6,2161
+    hackage: posix-pty-0.2.2@sha256:dd777df258b3b95fe01612c1204cde972ad1323c3289591ecc844ecb29e55e2b,1826
 snapshots:
 - completed:
-    size: 523700
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/7.yaml
-    sha256: 8e3f3c894be74d71fa4bf085e0a8baae7e4d7622d07ea31a52736b80f8b9bb1a
-  original: lts-14.7
+    size: 563100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/0.yaml
+    sha256: e93a85871577ea3423d5f3454b2b6bd37c2c2123c79faf511dfb64f5b49a9f8b
+  original: lts-17.0

--- a/tests/fzf_bash.exp
+++ b/tests/fzf_bash.exp
@@ -1,0 +1,33 @@
+#!/usr/bin/expect -f
+
+set prompt ":$"
+set timeout 2
+
+spawn -noecho rpw bash
+
+send "unset PROMPT_COMMAND; PS1=:\r"
+expect *
+send \n
+expect -re $prompt
+
+send "echo oi\r"
+expect {
+    "echo oi\r\n" { }
+    timeout { puts "timeout after command"; exit 1 }
+}
+expect {
+    "oi\r\n" { }
+    timeout { puts "timeout while waiting echo"; exit 1 }
+}
+send "history | fzf --tac --no-sort\r"
+expect {
+    ">" { }
+    timeout { puts "timeout while choosing history"; exit 1 }
+}
+send "\033\[A"
+send "\r"
+
+expect {
+    "echo oi\r\n" { puts "OK" }
+    timeout { puts "timeout after fzf exit"; exit 1 }
+}

--- a/tests/fzf_zsh.exp
+++ b/tests/fzf_zsh.exp
@@ -1,0 +1,36 @@
+#!/usr/bin/expect -f
+
+set prompt ":"
+set timeout 2
+
+spawn -noecho env ZDOTDIR=$env(PWD)/tests/ rpw zsh
+
+send "unset PROMPT_COMMAND; PS1=:\r"
+expect *
+expect {
+    "$prompt" { }
+    timeout { puts "startup error"; exit 1 }
+}
+expect *
+
+send "echo oi\r"
+expect {
+    -re ".*echo oi.*" { }
+    timeout { puts "timeout sending command"; exit 1 }
+}
+expect {
+    -re ".*\r\noi.*$prompt" { }
+    timeout { puts "timeout while waiting echo"; exit 1 }
+}
+send "history | fzf --tac --no-sort\r"
+expect {
+    ">" { }
+    timeout { puts "timeout while choosing history"; exit 1 }
+}
+send "\033\[A"
+send "\r"
+
+expect {
+    -re "unset PROMPT_COMMAND; PS1=:" { puts "OK" }
+    timeout { puts "timeout after fzf exit"; exit 1 }
+}


### PR DESCRIPTION


Some stty flags that were being set on both master and stlave ttys
were not needed, apparently. In particular, some combination of flags
on both prevented, for example, `fzf` and `vim` from capturing
`Enter` somehow.

Using `raw iutf8` for master and `sane` for slave ttys seems to have
sufficed to fix this and keep previous fetatures. I'm not sure if
`iutf8` is really needed on master, but it was not being set in `rpw
zsh` but my `zsh` usually has this enabled. Also, `sane` was not
needed for `zsh` but `bash` apparently inherits `-icanon` from parent
or something, which breaks the expected `cat` behavior. Using `sane`
fixed this for `bash` and seems to have no negative effect on `zsh.

